### PR TITLE
Add recording links to 2023-05

### DIFF
--- a/2023-05/README.md
+++ b/2023-05/README.md
@@ -1,0 +1,4 @@
+| Topic   | Recording                                                     | Materials                                                          |
+|---------|---------------------------------------------------------------|--------------------------------------------------------------------|
+| Lunatic | [on YouTube](https://www.youtube.com/watch?v=xJg_En_7O8A)     | [slides](lunatic-erlang-inspired-runtime-for-rust.pdf)             |
+| RIOT OS | [on YouTube](https://www.youtube.com/watch?v=kWUoe3B7_18)     | [slides](rust-on-riot/slides.pdf), [links](rust-on-riot/README.md) |

--- a/2023-05/rust-on-riot/README.md
+++ b/2023-05/rust-on-riot/README.md
@@ -3,6 +3,8 @@ Extended lightning talk on using Rust on embedded devices
 Mainly an update on [the 2018-11-27 Rust meetup presentation](http://christian.amsuess.com/presentations/2018/embedded-rust-riot/),
 also using materials assembled for the [2019-04-27 talk "iron parts on deep roots" at the Oxidize conference](https://www.youtube.com/watch?v=9XDnXM64sbE) in Berlin.
 
+A [recording is available](https://www.youtube.com/watch?v=kWUoe3B7_18).
+
 ----
 
 All materials are licensed under the terms of [CC-BY](https://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
For my presentation there's already a README, but given there's no such structure for the other one, I'm just adding a table.